### PR TITLE
RMX1901: KeyHandler: fix? Somehow.

### DIFF
--- a/camera_helper/src/org/lineageos/camerahelper/KeyHandler.java
+++ b/camera_helper/src/org/lineageos/camerahelper/KeyHandler.java
@@ -46,7 +46,7 @@ public class KeyHandler implements DeviceKeyHandler {
         mContext = context;
     }
 
-    public KeyEvent handleKeyEvent(KeyEvent event) {
+    public boolean handleKeyEvent(KeyEvent event) {
         int scanCode = event.getScanCode();
 
         switch (scanCode) {
@@ -66,10 +66,10 @@ public class KeyHandler implements DeviceKeyHandler {
                 }
                 break;
             default:
-                return event;
+                return false;
         }
 
-        return null;
+        return true;
     }
 
     private Context getPackageContext() {
@@ -78,7 +78,7 @@ public class KeyHandler implements DeviceKeyHandler {
         } catch (NameNotFoundException | SecurityException e) {
             Log.e(TAG, "Failed to create package context", e);
         }
-        return null;
+        return true;
     }
 
     private void showCameraMotorCannotGoDownWarning() {


### PR DESCRIPTION
 *log: device/realme/RMX1901/camera_helper/src/org/lineageos/camerahelper/KeyHandler.java:31: error: KeyHandler is not abstract and does not override abstract method isActivityLaunchEvent(KeyEvent) in DeviceKeyHandler
public class KeyHandler implements DeviceKeyHandler {
       ^
device/realme/RMX1901/camera_helper/src/org/lineageos/camerahelper/KeyHandler.java:49: error: handleKeyEvent(KeyEvent) in KeyHandler cannot implement handleKeyEvent(KeyEvent) in DeviceKeyHandler
    public KeyEvent handleKeyEvent(KeyEvent event) {
                    ^
  return type KeyEvent is not compatible with boolean
2 errors

Signed-off-by: Mayur <ultramayur123@gmail.com>